### PR TITLE
Add flakelight-darwin ref in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ The following modules are also available:
 - [flakelight-rust][] for Rust projects
 - [flakelight-zig][] for Zig projects
 - [flakelight-elisp][] for flakes providing Emacs lisp package(s)
+- [flakelight-darwin][] for nix-darwin configs
 
 [flakelight-rust]: https://github.com/accelbread/flakelight-rust
 [flakelight-zig]: https://github.com/accelbread/flakelight-zig
 [flakelight-elisp]: https://github.com/accelbread/flakelight-elisp
+[flakelight-darwin]: https://github.com/cmacrae/flakelight-darwin
 
 ## Contact
 


### PR DESCRIPTION
Hey @accelbread 👋 I've found flakelight to be a breath of fresh air for composing my configurations, so thanks very much for creating and sharing it :)

These changes include Darwin support, via nix-darwin. It's pretty much a copy & paste of the NixOS code.  
It works nicely - I'm using it to configure a MacBook I have. I'd like to be thorough with the tests, however adding an equivalent `darwinConfiguration` test would require adding nix-darwin to the inputs, which I figured wasn't ideal.

I appreciate updating the default systems to include Darwin may not be desirable, so happy to back that change out if you'd prefer. Also feel free to suggest any changes to wording you'd like to see in the API docs