### PR TITLE
Use direct flake url for nixpkgs

### DIFF
--- a/API_GUIDE.md
+++ b/API_GUIDE.md
@@ -106,7 +106,7 @@ To use a different nixpkgs from the built-in default (passing all inputs):
 {
   inputs = {
     flakelight.url = "github:nix-community/flakelight";
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
   outputs = { flakelight, ... }@inputs:
     flakelight ./. {
@@ -120,7 +120,7 @@ Or to just pass just the nixpkgs input:
 ```nix
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flakelight.url = "github:nix-community/flakelight";
   };
   outputs = { flakelight, nixpkgs, ... }:
@@ -803,7 +803,7 @@ For example:
 {
   inputs = {
     flakelight.url = "github:nix-community/flakelight";
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
   outputs = { flakelight, nixpkgs, ... }:
     flakelight ./. {

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ To use a different nixpkgs, you can instead use:
 ```nix
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flakelight.url = "github:nix-community/flakelight";
   };
   outputs = { flakelight, ... }@inputs:

--- a/flake.lock
+++ b/flake.lock
@@ -10,9 +10,10 @@
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 {
   description =
     "A modular Nix flake framework for simplifying flake definitions";
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   outputs = inputs:
     let lib = import ./. inputs; in
     lib.mkFlake ./. {

--- a/templates/basic/flake.nix
+++ b/templates/basic/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flakelight.url = "github:nix-community/flakelight";
   };
   outputs = { flakelight, ... }@inputs:


### PR DESCRIPTION
Follow the same convention as,
- [ home-manager](https://github.com/nix-community/home-manager/blob/master/flake.nix#L4)
- [disko](https://github.com/nix-community/disko/blob/master/flake.nix#L7)
- [nix](https://github.com/NixOS/nix/blob/master/flake.nix#L6)

No need to download flake-registry anymore.