### PR TITLE
Ignore node_modules when performing diff for formatting check

### DIFF
--- a/builtinModules/formatter.nix
+++ b/builtinModules/formatter.nix
@@ -57,7 +57,7 @@ in
     (mkIf ((config.formatters != null) || (config.formatter != null)) {
       checks.formatting = { lib, outputs', diffutils, ... }: ''
         ${lib.getExe outputs'.formatter} .
-        ${diffutils}/bin/diff -qr ${src} . |\
+        ${diffutils}/bin/diff --exclude=node_modules -qr ${src} . |\
           sed 's/Files .* and \(.*\) differ/File \1 not formatted/g'
       '';
     })


### PR DESCRIPTION
For some reason running `prettier` on a `package.json` will create a `node_modules` folder, causing the formatting to check to always fail for projects with a `package.json`